### PR TITLE
update to master rust

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,7 @@ impl UnsafeAny {
 }
 
 /// An extension trait for unchecked downcasting of trait objects.
-pub trait UnsafeAnyExt for Sized? {
+pub trait UnsafeAnyExt {
     /// Returns a reference to the contained value, assuming that it is of type `T`.
     ///
     /// ## Warning


### PR DESCRIPTION
The `for Sized?` is deprecated form and not necessary now.